### PR TITLE
Added instructions for migrating to Breakpoint 2.x or staying at Breakpoint 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ You've always wanted a nice, natural language way to name and remember your brea
 
 The active development of this extension has been moved into [Breakpoint 2.x](https://github.com/Team-Sass/breakpoint).
 
-If you've been using the Respond To gem in your project and have updated the Breakpoint gem to 2.x, you should remove all mentions of the Respond To gem from your project. Please check the following locations and either remove or comment out the lines:
+If you've been using the Respond To gem in your project and have updated the Breakpoint gem to 2.x, you have two options: migrate your project to Breakpoint 2.x or revert to Breakpoint 1.x.
+
+### Mirgrating to Breakpoint 2.x
+
+ you should remove all mentions of the Respond To gem from your project. Please check the following locations and either remove or comment out the lines:
 
 File to check                          | Line to remove
 -------------------------------------- | --------------
@@ -15,6 +19,17 @@ config.rb                              | `require 'respond-to'`
 style.scss (or a partial with imports) | `@import respond-to;`
 
 Then recompile your project and you're good to go!
+
+### Reverting to Breakpoint 1.x
+
+You can use [Bundler](http://gembundler.com/) to keep the Breakpoint gem at version 1.x.
+
+Make sure you require Breakpoint 1.x in your Gemfile:
+
+    gem 'breakpoint', '~>1.3'
+    gem 'respond-to'
+
+Then run `bundle install` from within your project's dir.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Respond-to also requires Sass 3.2, which was just recently released. Respond-to 
 
 If you are compiling with CodeKit, [Chris Coyier has an awesome writeup](http://css-tricks.com/media-queries-sass-3-2-and-codekit/) on how to get CodeKit playing nice with Sass 3.2.
 
+Respond To requires Breakpoint 1.x. See the above section for insructions.
+
 ## Install
 
 `gem install respond-to`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 You've always wanted a nice, natural language way to name and remember your breakpoints, and now you can have it! Introducing Respond-to, a compass extension giving you the power of a [Variable Driven respond-to mixin](https://gist.github.com/2493551) for you to use in your projects now!
 
+## Respond To has been merged into Breakpoint
+
+The active development of this extension has been moved into [Breakpoint 2.x](https://github.com/Team-Sass/breakpoint).
+
+If you've been using the Respond To gem in your project and have updated the Breakpoint gem to 2.x, you should remove all mentions of the Respond To gem from your project. Please check the following locations and either remove or comment out the lines:
+
+File to check                          | Line to remove
+-------------------------------------- | --------------
+Gemfile                                | `gem 'respond-to'`
+config.rb                              | `require 'respond-to'`
+style.scss (or a partial with imports) | `@import respond-to;`
+
+Then recompile your project and you're good to go!
+
 ## Requirements
 
 Respond-to is a Compass extension, so make sure you have [Sass and Compass Installed](http://compass-style.org/install/) in order to use its awesomeness!


### PR DESCRIPTION
`bundle update` has broken my project today.

It took me some time to figure things out. I've added instructions for migrating to Breakpoint 2.x or staying at Breakpoint 1.x.
